### PR TITLE
W-035453 Update references to sfdx-lwc-jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const { jestConfig } = require('@salesforce/lwc-jest/config');
+const { jestConfig } = require('@salesforce/sfdx-lwc-jest/config');
 module.exports = {
     ...jestConfig,
     moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/SalesforceFoundation/gem#readme",
   "devDependencies": {
-    "@salesforce/lwc-jest": "^0.4.14"
+    "@salesforce/sfdx-lwc-jest": "^0.5.4"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -6,5 +6,5 @@
     }
   ],
   "namespace": "gem",
-  "sourceApiVersion": "45.0"
+  "sourceApiVersion": "46.0"
 }


### PR DESCRIPTION
We added backend tests to validate Lightning Web Components functionality, when customizing the Single Gift Entry form. 
We've updated all code that references sfdx-jest to now point to sfdx-lwc-jest. This allows our Lightning Web Components to be tested internally. (winter 20)


# Critical Changes

# Changes


# Issues Closed
Closes #204 
# New Metadata

# Deleted Metadata

# Testing Notes
- In the command line, run `npm install` and then `npm run test:unit`. All tests should pass.
- When you check out the branch and run `npm install` you should see some references to `sfdx-lwc-jest` scroll by, and inside node_modules/@salesforce you should see the sfdx-lwc-jest directory.