### PR TITLE
Make Opportunity Stage a required field in SGE

### DIFF
--- a/src/aura/giftEntryForm/giftEntryForm.cmp
+++ b/src/aura/giftEntryForm/giftEntryForm.cmp
@@ -257,10 +257,16 @@
                         </lightning:layoutItem>
 
                         <lightning:layoutItem padding="around-small" size="6" mediumDeviceSize="3">
-                            <c:giftPicklist picklistValues="{!v.objectFieldData.picklistOptions.npsp__Donation_Stage__c}"
-                                fieldLabel="{!v.objectFieldData.objectLabels.Opportunity.StageName}"
-                                disabled="{!v.oppClosed}"
-                                selectedVal="{!v.opp.StageName}" />
+                            <label class="show-required slds-form-element__label">
+                                {!v.objectFieldData.objectLabels.Opportunity.StageName}
+                            </label>
+                            <aura:if isTrue="{!v.renderRequiredInputs}">
+                                <lightning:inputField aura:id="requiredField" 
+                                    disabled="{!v.oppClosed}"
+                                    variant="label-hidden"
+                                    fieldName="StageName"
+                                    value="{!v.opp.StageName}" />
+                            </aura:if>
                         </lightning:layoutItem>
 
                         <lightning:layoutItem padding="around-small" size="6" mediumDeviceSize="3"


### PR DESCRIPTION
# Critical Changes

# Changes

- We're making the Opportunity Stage required on the Single Gift Entry form. Previously, it would default to the org's "Closed Won" stage when left blank.

# Issues Closed

Fixes #209 

# New Metadata

# Deleted Metadata

# Testing Notes

- Enter a gift using SGE and make sure that the Opportunity Stage field is now required to Save.
- Get the Stage field in an "error state", then load an existing gift and make sure field validation is accurate.
