### PR TITLE
Fixing SGE access issue in Winter 20

### DIFF
--- a/src/aura/giftEntryForm/giftEntryForm.cmp
+++ b/src/aura/giftEntryForm/giftEntryForm.cmp
@@ -102,12 +102,12 @@
         </header>
         <div class="outerDivContainer">
         <div class="slds-card" aura:id="formWrapper">
+            <lightning:layout
+                multipleRows="true">
             <lightning:recordEditForm objectApiName="Opportunity"
                 recordId="{!v.opp.Id}">
             <lightning:messages />
 
-            <lightning:layout
-                multipleRows="true">
                 <lightning:layoutItem size="12">
                     <div class="slds-page-header slds-page-header__title">
                         <h2>{!$Label.c.Gift_Donor_Information}</h2>
@@ -341,15 +341,6 @@
                     objectFieldData="{!v.objectFieldData}"
                     giftModel="{!v.giftModel}" />
 
-                <lightning:layoutItem size="12" aura:id="dynamicFormContainer" class="slds-hidden">
-                    <c:sge_dynamicForm
-                        sobject="{!v.opp}"
-                        disableinputs="{!v.oppClosed}"
-                        aura:id="sge_dynamicForm"
-                        onload="{!c.handleDynamicFormLoaded}">
-                    </c:sge_dynamicForm>
-                </lightning:layoutItem>
-
                 <aura:if isTrue="{!v.submitError}">
                     <div id="submitError"
                     class="{!v.messageIsError == true
@@ -387,8 +378,18 @@
                     <lightning:input aura:id="oppId"
                         value="{!v.giftModel.oppId}" />
                 </div>
-            </lightning:layout>
             </lightning:recordEditForm>
+
+                <lightning:layoutItem size="12" aura:id="dynamicFormContainer" class="slds-hidden">
+                    <c:sge_dynamicForm
+                        sobject="{!v.opp}"
+                        disableinputs="{!v.oppClosed}"
+                        aura:id="sge_dynamicForm"
+                        onload="{!c.handleDynamicFormLoaded}">
+                    </c:sge_dynamicForm>
+                </lightning:layoutItem>
+
+            </lightning:layout>
         </div>
         </div>
     </aura:if>

--- a/src/aura/giftEntryForm/giftEntryForm.cmp
+++ b/src/aura/giftEntryForm/giftEntryForm.cmp
@@ -102,12 +102,12 @@
         </header>
         <div class="outerDivContainer">
         <div class="slds-card" aura:id="formWrapper">
-            <lightning:layout
-                multipleRows="true">
             <lightning:recordEditForm objectApiName="Opportunity"
                 recordId="{!v.opp.Id}">
             <lightning:messages />
 
+            <lightning:layout
+                multipleRows="true">
                 <lightning:layoutItem size="12">
                     <div class="slds-page-header slds-page-header__title">
                         <h2>{!$Label.c.Gift_Donor_Information}</h2>
@@ -378,8 +378,10 @@
                     <lightning:input aura:id="oppId"
                         value="{!v.giftModel.oppId}" />
                 </div>
+            </lightning:layout>
             </lightning:recordEditForm>
 
+            <lightning:layout>
                 <lightning:layoutItem size="12" aura:id="dynamicFormContainer" class="slds-hidden">
                     <c:sge_dynamicForm
                         sobject="{!v.opp}"
@@ -388,8 +390,8 @@
                         onload="{!c.handleDynamicFormLoaded}">
                     </c:sge_dynamicForm>
                 </lightning:layoutItem>
-
             </lightning:layout>
+            
         </div>
         </div>
     </aura:if>

--- a/src/aura/giftEntryForm/giftEntryForm.cmp
+++ b/src/aura/giftEntryForm/giftEntryForm.cmp
@@ -102,12 +102,14 @@
         </header>
         <div class="outerDivContainer">
         <div class="slds-card" aura:id="formWrapper">
+            
+            <lightning:layout
+                multipleRows="true">
+            <lightning:layoutItem size="12">
             <lightning:recordEditForm objectApiName="Opportunity"
                 recordId="{!v.opp.Id}">
             <lightning:messages />
 
-            <lightning:layout
-                multipleRows="true">
                 <lightning:layoutItem size="12">
                     <div class="slds-page-header slds-page-header__title">
                         <h2>{!$Label.c.Gift_Donor_Information}</h2>
@@ -378,10 +380,9 @@
                     <lightning:input aura:id="oppId"
                         value="{!v.giftModel.oppId}" />
                 </div>
-            </lightning:layout>
             </lightning:recordEditForm>
+            </lightning:layoutItem>
 
-            <lightning:layout>
                 <lightning:layoutItem size="12" aura:id="dynamicFormContainer" class="slds-hidden">
                     <c:sge_dynamicForm
                         sobject="{!v.opp}"

--- a/src/aura/giftFormRelatedRow/giftFormRelatedRow.css
+++ b/src/aura/giftFormRelatedRow/giftFormRelatedRow.css
@@ -18,7 +18,7 @@
     width: 0;
 }
 .THIS .select-container .slds-form-element__label {
-    display: none;
+    display: none !important;
 }
 /*
 .THIS .uiInput--default .form-element__label {

--- a/src/classes/GiftEntryFormController.cls
+++ b/src/classes/GiftEntryFormController.cls
@@ -50,9 +50,9 @@ public with sharing class GiftEntryFormController {
 
         @AuraEnabled public Map<String, Map<String,String>> objNameToApiToLabel {get;set;}
         @AuraEnabled public Map<String, String> bdiLabels;
-        @AuraEnabled Map<String, List<String>> picklistValues {get;set;}
-        @AuraEnabled Map<String, Boolean> closedWonStageMap {get;set;}
-        @AuraEnabled Map<String, String> diToOppFieldMap {get;set;}
+        @AuraEnabled public Map<String, List<String>> picklistValues {get;set;}
+        @AuraEnabled public Map<String, Boolean> closedWonStageMap {get;set;}
+        @AuraEnabled public Map<String, String> diToOppFieldMap {get;set;}
 
         public GiftFormModel() {
             this.objNameToApiToLabel = getObjNameToApiToLabel();

--- a/src/lwc/sge_formField/sge_formField.js
+++ b/src/lwc/sge_formField/sge_formField.js
@@ -39,7 +39,15 @@
 import {LightningElement, api, track} from 'lwc';
 
 export default class SGE_FormField extends LightningElement {
-    @api sobject;
+    @api
+    get sobject(){
+        return this._sobject;
+    }
+    set sobject(value){
+        this.setAttribute('sobject', value);
+        this._sobject = value;
+        this.value = this.sobject[this.field.name];
+    }
     @api disableInputs;
     @api field = {};
     @track value;


### PR DESCRIPTION
# Critical Changes

# Changes

- We fixed a bug in Single Gift Entry for Winter '20 orgs that was caused by new apex security updates.

# Issues Closed

- Fixes: #214 

# New Metadata

# Deleted Metadata

# Testing Notes
- Build a pre_release scratch org.
- Loading the SGE form should not report any errors (previously it reported "Could not find picklist values for field")
- Blurring the Amount field should no longer report an error.
- The "gap" above the Role Name picklist in the Soft Credits section should be gone.
- Per usual, it's worth doing some smoke testing, especially around loading and editing existing Opportunities.
