### PR TITLE
Replacing "HEDA" with "EDA" in customer facing strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gift Entry Manager
 
-Salesforce.org Gift Entry Manager (“GEM”) is an extensible application with open source and closed source components that leverages existing fundraising capabilities, built on EDA, with new code to address the unique core needs of higher education gift entry management. GEM utilizes Salesforce.com (“Salesforce”) managed packages to give higher education users the ability to record gifts and pledges. In addition, GEM developers and administrators can benefit from insights beyond gift records, manage extensible pledge and gift management in the cloud, and utilize a robust framework for gift entry from single to batch workflows.
+Salesforce.org Gift Entry Manager (“GEM”) is an extensible application with open source and closed source components that leverages existing fundraising capabilities, built on EDA, with new code to address the unique core needs of educational gift entry management. GEM utilizes Salesforce.com (“Salesforce”) managed packages to give educational users the ability to record gifts and pledges. In addition, GEM developers and administrators can benefit from insights beyond gift records, manage extensible pledge and gift management in the cloud, and utilize a robust framework for gift entry from single to batch workflows.
 
-GEM is driven by customer feedback across higher education and the Salesforce ecosystem and we welcome feedback and contributions for the project.  For clarity, GEM is a Non-SFDC Application or a Third-Party Application, and not Services, under any master subscription agreement with Salesforce.
+GEM is driven by customer feedback across the education sector and the Salesforce ecosystem and we welcome feedback and contributions for the project.  For clarity, GEM is a Non-SFDC Application or a Third-Party Application, and not Services, under any master subscription agreement with Salesforce.
 
 We are proud to offer GEM to our U.S. market, prior to its worldwide availability. Refer to [the documentation](https://powerofus.force.com/s/article/GEM-Documentation) for information on installing and configuring GEM. 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gem",
   "version": "1.0.0",
-  "description": "Salesforce.org Gift Entry Manager (“GEM”) is an open source, extensible application that leverages existing fundraising capabilities, built on HEDA, with new code to address the unique core needs of higher education gift entry management. GEM  utilizes a Salesforce.com (“Salesforce”) managed package to give higher education users the ability to record gifts and pledges. In addition, GEM developers and administrators can benefit from insights beyond gift records, manage extensible pledge and gift management in the cloud, and utilize a robust framework for gift entry from single to batch workflows.",
+  "description": "Salesforce.org Gift Entry Manager (“GEM”) is an open source, extensible application that leverages existing fundraising capabilities, built on EDA, with new code to address the unique core needs of educational gift entry management. GEM  utilizes a Salesforce.com (“Salesforce”) managed package to give educational users the ability to record gifts and pledges. In addition, GEM developers and administrators can benefit from insights beyond gift records, manage extensible pledge and gift management in the cloud, and utilize a robust framework for gift entry from single to batch workflows.",
   "scripts": {
     "test:unit": "lwc-jest",
     "test:unit:watch": "lwc-jest --watch",

--- a/src/objects/GEM_API_Settings__mdt.object
+++ b/src/objects/GEM_API_Settings__mdt.object
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>Configuration that enables sync between HEDA, GEM, and NPSP. WARNING: Do not change these settings unless directed by Salesforce.org support.</description>
+    <description>Configuration that enables sync between EDA, GEM, and NPSP. WARNING: Do not change these settings unless directed by Salesforce.org support.</description>
     <fields>
         <fullName>API_HEDA_Class__c</fullName>
         <defaultValue>&apos;API_HEDA&apos;</defaultValue>
-        <description>The name of the class that enables HEDA to access the Gift Entry Management TDTM interface. Do not change the default value for this field.</description>
+        <description>The name of the class that enables EDA to access the Gift Entry Management TDTM interface. Do not change the default value for this field.</description>
         <externalId>false</externalId>
         <fieldManageability>SubscriberControlled</fieldManageability>
-        <inlineHelpText>The name of the class that enables HEDA to access the Gift Entry Management TDTM interface. Do not change the default value for this field.</inlineHelpText>
-        <label>API HEDA Class</label>
+        <inlineHelpText>The name of the class that enables EDA to access the Gift Entry Management TDTM interface. Do not change the default value for this field.</inlineHelpText>
+        <label>API EDA Class</label>
         <length>255</length>
         <required>false</required>
         <type>Text</type>
@@ -30,10 +30,10 @@
     <fields>
         <fullName>Use_GEM__c</fullName>
         <defaultValue>true</defaultValue>
-        <description>Enable Gift Entry Management managed package in HEDA and NPSP. Do not change the default value for this field.</description>
+        <description>Enable Gift Entry Management managed package in EDA and NPSP. Do not change the default value for this field.</description>
         <externalId>false</externalId>
         <fieldManageability>SubscriberControlled</fieldManageability>
-        <inlineHelpText>Enable Gift Entry Management managed package in HEDA and NPSP. Do not change the default value for this field.</inlineHelpText>
+        <inlineHelpText>Enable Gift Entry Management managed package in EDA and NPSP. Do not change the default value for this field.</inlineHelpText>
         <label>Use GEM</label>
         <type>Checkbox</type>
     </fields>

--- a/src/objects/GEM_Settings__c.object
+++ b/src/objects/GEM_Settings__c.object
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <customSettingsType>Hierarchy</customSettingsType>
-    <description>Settings relating to Gift Entry, including options for how HEDA and NPSP interact.</description>
+    <description>Settings relating to Gift Entry, including options for how EDA and NPSP interact.</description>
     <enableFeeds>false</enableFeeds>
     <fields>
         <fullName>Sync_Account_Models__c</fullName>
         <defaultValue>false</defaultValue>
-        <description>If checked, the Account model settings from HEDA will overwrite the equivalent settings in NPSP.</description>
+        <description>If checked, the Account model settings from EDA will overwrite the equivalent settings in NPSP.</description>
         <externalId>false</externalId>
-        <inlineHelpText>If checked, the Account model settings from HEDA will overwrite the equivalent settings in NPSP.</inlineHelpText>
+        <inlineHelpText>If checked, the Account model settings from EDA will overwrite the equivalent settings in NPSP.</inlineHelpText>
         <label>Sync Account Models</label>
         <trackTrending>false</trackTrending>
         <type>Checkbox</type>


### PR DESCRIPTION
# Critical Changes

# Changes

- We updated "HEDA" references to instead say "EDA", due to the renaming of that managed package.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes

- Make sure the "HEDA" and "Higher Education" references in this doc were correctly updated to the recommended text: https://salesforce.quip.com/Kbv2Afae9g6N
