### PR TITLE
Removing record type references from managed Permission Set

### DIFF
--- a/scripts/configure_default_settings.cls
+++ b/scripts/configure_default_settings.cls
@@ -7,6 +7,7 @@
 */
 String adminEmail = 'testing@example.com';
 String giftEntryPS = 'GEM Gift Entry';
+String giftEntryPS2 = 'GEM Record Type Access';
 String giftProfileName = 'Standard User';
 
 private static %%%NAMESPACE%%%GEM_Settings__c orgGemSettings;
@@ -112,6 +113,7 @@ public static void AddGiftProcessor() {
         ];
 
         PermissionSet ps = [SELECT Id FROM PermissionSet WHERE Label =: giftEntryPS];
+        PermissionSet ps2 = [SELECT Id FROM PermissionSet WHERE Label =: giftEntryPS2];
         
         List<User> giftProcessors = [SELECT Id FROM User WHERE ProfileId = :newUserProfile.Id AND IsActive = true];
         if(giftProcessors.size() == 0) {
@@ -133,6 +135,7 @@ public static void AddGiftProcessor() {
             insert users;
 
             insert new PermissionSetAssignment(AssigneeId = users[0].Id, PermissionSetId = ps.Id);
+            insert new PermissionSetAssignment(AssigneeId = users[0].Id, PermissionSetId = ps2.Id);
         }
     } catch (System.DmlException e) {
         Database.rollback(sp);

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -43,7 +43,7 @@ public class UTIL_UnitTestData_TEST {
     *******************************************************************************************************/
     private static string closedWonStage;
     private static string openStage;
-    public static String giftEntryPS = 'Gift Entry';
+    public static String giftEntryPS = 'GEM Gift Entry';
 
     /*******************************************************************************************************
     * @description Returns opportunity closed won stage

--- a/src/permissionsets/GEM_Gift_Entry.permissionset
+++ b/src/permissionsets/GEM_Gift_Entry.permissionset
@@ -928,34 +928,6 @@
         <object>npsp__Partial_Soft_Credit__c</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
-    <recordTypeVisibilities>
-        <recordType>Account.Administrative</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
-    <recordTypeVisibilities>
-        <recordType>Account.Business_Organization</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
-    <recordTypeVisibilities>
-        <recordType>Account.Educational_Institution</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
-    <recordTypeVisibilities>
-        <recordType>Account.HH_Account</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
-    <recordTypeVisibilities>
-        <recordType>Account.Organization</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
-    <recordTypeVisibilities>
-        <recordType>Account.University_Department</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
-    <recordTypeVisibilities>
-        <recordType>Opportunity.Donation</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
     <tabSettings>
         <tab>Single_Gift_Entry</tab>
         <visibility>Visible</visibility>

--- a/src/permissionsets/GEM_Gift_Entry.permissionset
+++ b/src/permissionsets/GEM_Gift_Entry.permissionset
@@ -16,7 +16,11 @@
         <apexClass>GiftEntryFormController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
-    <description>Lets a user access the data required for Gift Entry.</description>
+    <classAccesses>
+        <apexClass>SGE_GiftEntryService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <description>Grants access to the tools and data structure required for Gift Entry.</description>
     <fieldPermissions>
         <editable>true</editable>
         <field>Opportunity.AccountId</field>

--- a/unpackaged/config/recommended/package.xml
+++ b/unpackaged/config/recommended/package.xml
@@ -7,6 +7,10 @@
         <name>Layout</name>
     </types>
     <types>
+        <members>GEM_Record_Type_Access</members>
+        <name>PermissionSet</name>
+    </types>
+    <types>
         <members>New_Household_Account</members>
         <name>QuickAction</name>
     </types>

--- a/unpackaged/config/recommended/permissionsets/GEM_Record_Type_Access.permissionset
+++ b/unpackaged/config/recommended/permissionsets/GEM_Record_Type_Access.permissionset
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Grants access to record types required by GEM. Assign this permission set to users who have the GEM Gift Entry permission set.</description>
+    <label>GEM Record Type Access</label>
+    <recordTypeVisibilities>
+        <recordType>Account.Administrative</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Account.Business_Organization</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Account.Educational_Institution</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Account.HH_Account</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Account.Organization</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Account.University_Department</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>Opportunity.Donation</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+</PermissionSet>


### PR DESCRIPTION
- This is a bug fix for our new managed permission set, but it may also include some documentation changes, since I found out we can't include Record Types in the permission set.

# Critical Changes

# Changes

- We're adding an unmanaged Permission Set to the installer that provides access to record type visibilities required by GEM.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
