### PR TITLE
Add second installer plan for EMEA orgs

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -492,6 +492,49 @@ plans:
               action: error
               message: "Sorry, this product is not available in your region."
 
+    emea:
+        slug: emea
+        title: Install GEM
+        tier: Secondary
+        description: Installs the Gift Entry Manager
+        is_listed: False
+        steps:
+            1:
+                flow: install_prod_with_abacus
+            2:
+                task: deploy_post
+                options:
+                    unmanaged: False
+            3:
+                task: deploy_opp_record_types
+                checks:
+                    - when: "tasks.opp_record_types_exist()"
+                      action: skip
+                      message: Skipped because Opportunity record types already exist.
+                options:
+                    unmanaged: False
+            4:
+                task: deploy_installer_config
+                options:
+                    unmanaged: False
+            5:
+                task: deploy_dev_config
+                options:
+                    unmanaged: False
+                checks:
+                    - when: "'hed' in tasks.get_installed_packages()"
+                      action: hide
+            6:
+                task: execute_installer_settings
+                options:
+                    managed: True
+            7:
+                task: deploy_abacus_settings
+                options:
+                    managed: True
+            8:
+                task: deploy_trial_config
+
 orgs:
     scratch:
         dev_namespaced:


### PR DESCRIPTION
This PR adds a second installer plan for orgs that have been added
to the GEM Prerelease allowed list.

NOTE: This plan will require a manual plan-level allowed list at each
release until PlanTemplate allowed lists are implemented in MetaDeploy.


----

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes