### PR TITLE
Update picklist values on Contact to match HEDA

### DIFF
--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -87,8 +87,8 @@ public class UTIL_UnitTestData_TEST {
     *******************************************************************************************************/
     public static Contact getContact() {
         Contact contact =  new Contact(FirstName = 'Test', LastName = 'Testerson' + Datetime.now().getTime(),
-                hed__WorkEmail__c = 'fakeemail@salesforce.org', hed__Preferred_Email__c = 'Work',
-                hed__WorkPhone__c = '206-777-8888', hed__PreferredPhone__c = 'Work',OtherCity = 'Seattle');
+                hed__WorkEmail__c = 'fakeemail@salesforce.org', hed__Preferred_Email__c = 'Work Email',
+                hed__WorkPhone__c = '206-777-8888', hed__PreferredPhone__c = 'Work Phone',OtherCity = 'Seattle');
         Database.DMLOptions dmo = new Database.DMLOptions();
         dmo.DuplicateRuleHeader.AllowSave = true;
         contact.setOptions(dmo);
@@ -117,7 +117,7 @@ public class UTIL_UnitTestData_TEST {
         List<contact> ContactsToAdd = new List<contact>();
         for(Integer i=0; i<n; i++) {
             Contact newCon = new Contact(FirstName = i + 'Test' + i, LastName = i + 'Contact_forTests' + i, hed__WorkEmail__c = 'fakeemail' + i + '@salesforce.org',
-                    hed__Preferred_Email__c = 'Work', hed__WorkPhone__c = i + '06-777-888' + i, hed__PreferredPhone__c = 'Work', OtherCity = 'Seattle');
+                    hed__Preferred_Email__c = 'Work Email', hed__WorkPhone__c = i + '06-777-888' + i, hed__PreferredPhone__c = 'Work Phone', OtherCity = 'Seattle');
             Database.DMLOptions dmo = new Database.DMLOptions();
             dmo.DuplicateRuleHeader.AllowSave = true;
             newCon.setOptions(dmo);


### PR DESCRIPTION
- UTIL_UnitTestData_TEST: 
  - `Contact.hed__Preferred_Email__c` and `Contact.hed__PreferredPhone__c` picklist values has been updated on _EDA package_ making some GEM unit tests to fail. This change fixes all the gem unit tests that are currently failing due to `FIELD_CUSTOM_VALIDATION_EXCEPTION`

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
- All gem unit tests should pass.
- For more info, please refer to: [W-038359](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000001HqDJQA0/view)