### PR TITLE
HGE: added picklist field for do not create payments

### DIFF
--- a/src/classes/GiftEntryFormController_TEST.cls
+++ b/src/classes/GiftEntryFormController_TEST.cls
@@ -209,7 +209,7 @@ private class GiftEntryFormController_TEST {
     @isTest
     private static void testRunGiftProcessUpdate() {
         npsp__DataImport__c diObj = getTestDI();
-        diObj.Do_Not_Automatically_Create_Payment__c = true;
+        diObj.Do_Not_Automatically_Create_Payment2__c = 'true';
         diObj.npsp__Donation_Stage__c = openStage;
         insert diObj;
 

--- a/src/layouts/npsp__DataImport__c-GEM Gift Layout.layout
+++ b/src/layouts/npsp__DataImport__c-GEM Gift Layout.layout
@@ -507,7 +507,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Do_Not_Automatically_Create_Payment__c</field>
+                <field>Do_Not_Automatically_Create_Payment2__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>

--- a/src/objects/npsp__DataImport__c.object
+++ b/src/objects/npsp__DataImport__c.object
@@ -5,10 +5,36 @@
         <defaultValue>false</defaultValue>
         <description>Check to prevent automatic payment creation</description>
         <externalId>false</externalId>
-        <inlineHelpText>Opportunity.npe01__Do_Not_Automatically_Create_Payment__c</inlineHelpText>
+        <inlineHelpText></inlineHelpText>
         <label>Do Not Automatically Create Payment</label>
         <trackTrending>false</trackTrending>
         <type>Checkbox</type>
+    </fields>
+    <fields>
+        <fullName>Do_Not_Automatically_Create_Payment2__c</fullName>
+        <description>Check to prevent automatic payment creation</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Opportunity.npe01__Do_Not_Automatically_Create_Payment__c</inlineHelpText>
+        <label>Do Not Automatically Create Payment</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Picklist</type>
+        <valueSet>
+            <restricted>true</restricted>
+            <valueSetDefinition>
+                <sorted>false</sorted>
+                <value>
+                    <fullName>False</fullName>
+                    <default>false</default>
+                    <label>False</label>
+                </value>
+                <value>
+                    <fullName>True</fullName>
+                    <default>false</default>
+                    <label>True</label>
+                </value>
+            </valueSetDefinition>
+        </valueSet>       
     </fields>
     <fields>
         <fullName>Donation_Acknowledgment_Status__c</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -62,6 +62,7 @@
         <members>hed__Affiliation__c.Related_Opportunity_Contact_Role__c</members>
         <members>hed__Relationship__c.Related_Opportunity_Contact_Role__c</members>
         <members>npsp__DataImport__c.Do_Not_Automatically_Create_Payment__c</members>
+        <members>npsp__DataImport__c.Do_Not_Automatically_Create_Payment2__c</members>
         <members>npsp__DataImport__c.Donation_Acknowledgment_Status__c</members>
         <members>npsp__DataImport__c.Donation_Honoree_Contact__c</members>
         <members>npsp__DataImport__c.Donation_Honoree_Name__c</members>
@@ -133,9 +134,13 @@
         <members>Remaining_Amount</members>
         <members>Remove</members>
         <members>Required_Fields_Missing</members>
-        <members>Toggle</members>
         <members>Saving</members>
+        <members>Toggle</members>
         <name>CustomLabel</name>
+    </types>
+    <types>
+        <members>CustomLabels</members>
+        <name>CustomLabels</name>
     </types>
     <types>
         <members>GEM_API_Settings.GEM_config</members>
@@ -147,6 +152,33 @@
         <members>GEM_API_Settings__mdt</members>
         <members>Gift_Entry_Field_Mapping__mdt</members>
         <name>CustomObject</name>
+    </types>
+    <types>
+        <members>GEM_Settings__c-de</members>
+        <members>GEM_Settings__c-en_GB</members>
+        <members>GEM_Settings__c-es</members>
+        <members>GEM_Settings__c-fr</members>
+        <members>GEM_API_Settings__mdt-de</members>
+        <members>GEM_API_Settings__mdt-en_GB</members>
+        <members>GEM_API_Settings__mdt-es</members>
+        <members>GEM_API_Settings__mdt-fr</members>
+        <members>Gift_Entry_Field_Mapping__mdt-de</members>
+        <members>Gift_Entry_Field_Mapping__mdt-en_GB</members>
+        <members>Gift_Entry_Field_Mapping__mdt-es</members>
+        <members>Gift_Entry_Field_Mapping__mdt-fr</members>
+        <members>hed__Affiliation__c-de</members>
+        <members>hed__Affiliation__c-en_GB</members>
+        <members>hed__Affiliation__c-es</members>
+        <members>hed__Affiliation__c-fr</members>
+        <members>hed__Relationship__c-de</members>
+        <members>hed__Relationship__c-en_GB</members>
+        <members>hed__Relationship__c-es</members>
+        <members>hed__Relationship__c-fr</members>
+        <members>npsp__DataImport__c-de</members>
+        <members>npsp__DataImport__c-en_GB</members>
+        <members>npsp__DataImport__c-es</members>
+        <members>npsp__DataImport__c-fr</members>
+        <name>CustomObjectTranslation</name>
     </types>
     <types>
         <members>Single_Gift_Entry</members>
@@ -174,6 +206,13 @@
         <members>sge_formSection</members>
         <members>sge_service</members>
         <name>LightningComponentBundle</name>
+    </types>
+    <types>
+        <members>de</members>
+        <members>en_GB</members>
+        <members>es</members>
+        <members>fr</members>
+        <name>Translations</name>
     </types>
     <version>45.0</version>
 </Package>

--- a/unpackaged/config/dev/profiles/Admin.profile
+++ b/unpackaged/config/dev/profiles/Admin.profile
@@ -13,6 +13,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>npsp__DataImport__c.%%%NAMESPACE%%%Do_Not_Automatically_Create_Payment2__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>npsp__DataImport__c.%%%NAMESPACE%%%Donation_Acknowledgment_Status__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# Critical Changes

# Changes
Added new bdi import picklist field for Do Not Automatically create payments, so the field will not be required in HGE templates. (The existing field is of type checkbox, which produces an incorrect mapping).

# Issues Closed

# New Metadata
npsp__DataImport__c.gem__Do_Not_Automatically_Create_Payment2__c

# Deleted Metadata

# Testing Notes
