### PR TITLE
Remove EDA custom app from the permission set

### DIFF
--- a/unpackaged/config/recommended/permissionsets/Gift_Entry.permissionset
+++ b/unpackaged/config/recommended/permissionsets/Gift_Entry.permissionset
@@ -4,7 +4,6 @@
         <application>%%%NAMESPACE%%%Gift_Entry</application>
         <visible>true</visible>
     </applicationVisibilities>
-    </applicationVisibilities>
     <classAccesses>
         <apexClass>%%%NAMESPACE%%%DynamicFieldDisplayController</apexClass>
         <enabled>true</enabled>

--- a/unpackaged/config/recommended/permissionsets/Gift_Entry.permissionset
+++ b/unpackaged/config/recommended/permissionsets/Gift_Entry.permissionset
@@ -4,9 +4,6 @@
         <application>%%%NAMESPACE%%%Gift_Entry</application>
         <visible>true</visible>
     </applicationVisibilities>
-    <applicationVisibilities>
-        <application>hed__HEDA</application>
-        <visible>true</visible>
     </applicationVisibilities>
     <classAccesses>
         <apexClass>%%%NAMESPACE%%%DynamicFieldDisplayController</apexClass>


### PR DESCRIPTION
# Critical Changes

# Changes
Remove the HEDA custom app from the permission set in the unpackaged metadata invoked during the `install_prod.config_managed.deploy_installer_config` task. In the case when a subscriber deleted the custom app from their org, installation would fail.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
